### PR TITLE
Go driver compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Installation and Use
 --------------------
 Install Rust version 1.13 or greater.
 
+For Windows - tested under MSYS2 environment. Install freetype in
+MSYS2 with: `pacman -S mingw-w64-x86_64-freetype` or 
+`pacman -S mingw-w64-i686-freetype`. More info 
+[here](https://github.com/PistonDevelopers/freetype-sys).
+
 ```
 git clone https://github.com/echelon/etherdream-emulator.git
 cd etherdream-emulator

--- a/src/dac.rs
+++ b/src/dac.rs
@@ -1,8 +1,7 @@
 // Copyright (c) 2016 Brandon Thomas <bt@brand.io>, <echelon@gmail.com>
 
 use RuntimeOpts;
-use byteorder::LittleEndian;
-use byteorder::ReadBytesExt;
+use byteorder::{ByteOrder, LittleEndian, ReadBytesExt};
 use error::EmulatorError;
 use pipeline::Pipeline;
 use protocol::COMMAND_BEGIN;
@@ -148,7 +147,7 @@ impl Dac {
                      buf: [u8; 2048],
                      read_size: usize)
                      -> Result<(u16, Vec<u8>), EmulatorError> {
-    let num_points = read_u16(&buf[1 .. 3]);
+    let num_points = LittleEndian::read_u16(&buf[1 .. 3]);
 
     self.log(&format!("Reading {} points.", num_points));
 
@@ -203,12 +202,6 @@ impl Dac {
       println!("{}", message);
     }
   }
-}
-
-// TODO: Use the byteorder library instead.
-#[inline]
-fn read_u16(bytes: &[u8]) -> u16 {
-  ((bytes[0] as u16) << 8) | (bytes[1] as u16)
 }
 
 /// Parse a 'begin' command.

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,7 @@ fn broadcast_thread() {
   let udp = UdpBuilder::new_v4().unwrap();
   udp.reuse_address(true).unwrap();
 
-  let socket = udp.bind("0.0.0.0:7654").unwrap();
+  let socket = udp.bind("0.0.0.0:0").unwrap();
   socket.set_broadcast(true).unwrap();
 
   let multicast_ip = Ipv4Addr::new(255, 255, 255, 255);


### PR DESCRIPTION
bind to udp socket not required for bcast
Windows compilation notes
read_point_data - use LittleEndian encoding to read point count